### PR TITLE
Added config for a name/description field to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,6 +18,12 @@
             "type": "sub_settings",
             "repeatable": true,
             "sub_settings": [
+				{
+					"key": "section-description",
+					"name": "Name / Description (Optional)",
+					"required": false,
+					"type": "textarea"
+				},
                 {
                     "key": "copy-enabled",
                     "name": "Enabled?",


### PR DESCRIPTION
Added new description field so that you can name or describe each individual series of copy commands.