### PR TITLE
Trim whitespace from field name settings on save

### DIFF
--- a/CopyDataOnSave.php
+++ b/CopyDataOnSave.php
@@ -1221,7 +1221,7 @@ class CopyDataOnSave extends AbstractExternalModule {
             $importColumnsKeys = array_keys($importColumns);
 
             for ($i=0; $i < count($importColumns); $i++) { 
-                $importColumns[$importColumnsKeys[$i]] = $row[$i];
+                $importColumns[$importColumnsKeys[$i]] = trim($row[$i]);
             }
 
             // if changing the destination pid for an existing instruction, validate that user has design rights in destination project
@@ -1351,7 +1351,7 @@ class CopyDataOnSave extends AbstractExternalModule {
         $separators = array(PHP_EOL, ' ', '|');
         $settingArray = array();
         foreach ($separators as $sep) {
-            $split = explode($sep, trim($settingString));
+            $split = array_map('trim', explode($sep, trim($settingString)));
             if (count($split) > count($settingArray)) $settingArray = $split;
         }
         return $settingArray;
@@ -1381,6 +1381,16 @@ class CopyDataOnSave extends AbstractExternalModule {
      */
     public function redcap_module_save_configuration($project_id) {
         if (empty($project_id)) return;
+
+        // trim whitespace accidentally entered into the free-text field name settings
+        foreach (array('dest-event','dest-field') as $key) {
+            $value = $original = $this->getProjectSetting($key, $project_id);
+            if (is_array($value)) {
+                array_walk_recursive($value, function(&$v) { if (is_string($v)) $v = trim($v); });
+                if ($value !== $original) $this->setProjectSetting($key, $value, $project_id);
+            }
+        }
+
         $msm = new ModuleSettingsManager($this);
         $msm->saveCurrentSettingsToHistory();
     }


### PR DESCRIPTION
A field name typed into the configuration with an accidental leading or trailing
space fails confusingly: the name looks correct on screen, but is not found in the
project metadata, and the destination field name check reports *"contains invalid
characters"*.

This trims the two free-text settings that hold a field name when the configuration
is saved, in the existing `redcap_module_save_configuration()` hook:

- `dest-field` — *Destination field name*
- `dest-event` — *Destination event unique name*, which holds either an event unique
  name or a source field name

The other field/form settings are selected from a control (`field-list`, `form-list`,
`dropdown`) and so cannot pick up whitespace.

`array_walk_recursive` handles the nesting — `dest-event` is one value per instruction,
`dest-field` one per copy-field row within each instruction. The `!==` guard means an
already-clean configuration is not rewritten.

Related to #25, which trims the same kind of value at the point of use.


